### PR TITLE
Fix version check for GUI app context

### DIFF
--- a/ClaudeCodeStats/ClaudeCodeStats/Services/VersionService.swift
+++ b/ClaudeCodeStats/ClaudeCodeStats/Services/VersionService.swift
@@ -30,7 +30,7 @@ class VersionService {
             let pipe = Pipe()
 
             process.executableURL = URL(fileURLWithPath: "/bin/zsh")
-            process.arguments = ["-l", "-c", "claude --version"]
+            process.arguments = ["-li", "-c", "claude --version"]
             process.standardOutput = pipe
             process.standardError = FileHandle.nullDevice
 
@@ -148,15 +148,17 @@ class UpdateChecker: ObservableObject {
             return
         }
         lastCheckDate = Date()
-        do {
-            async let installed = VersionService.shared.fetchInstalledVersion()
-            async let latest = VersionService.shared.fetchLatestVersion()
-            let (installedResult, latestResult) = try await (installed, latest)
-            self.installedVersion = installedResult
-            self.latestVersion = latestResult
-        } catch {
-            // Silently fail — version check is non-critical
-        }
+
+        async let installedResult: String? = {
+            try? await VersionService.shared.fetchInstalledVersion()
+        }()
+        async let latestResult: String? = {
+            try? await VersionService.shared.fetchLatestVersion()
+        }()
+
+        let (installed, latest) = await (installedResult, latestResult)
+        if let installed { self.installedVersion = installed }
+        if let latest { self.latestVersion = latest }
     }
 
     func dismiss() {


### PR DESCRIPTION
## Summary
- Use `-li` (login+interactive) shell flag so `.zshrc` is sourced and nvm/node PATH is available when launched as a GUI app from /Applications
- Fetch installed and latest versions independently so a CLI lookup failure doesn't discard the GitHub API result
- Add `terminationStatus` check, 30-min throttle, `User-Agent` header, and release-specific changelog link

## Test plan
- [ ] Install via brew and verify "up to date" or update banner appears
- [ ] Verify version check works when `claude` is installed via nvm

🤖 Generated with [Claude Code](https://claude.com/claude-code)