### PR TITLE
Fix CI to properly ad-hoc sign the app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,6 @@ jobs:
             -arch arm64 -arch x86_64 \
             ONLY_ACTIVE_ARCH=NO \
             CODE_SIGN_IDENTITY="-" \
-            CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGNING_ALLOWED=NO \
             MARKETING_VERSION="$VERSION" \
             CURRENT_PROJECT_VERSION="1" \
             build


### PR DESCRIPTION
## Summary
- Remove `CODE_SIGNING_REQUIRED=NO` and `CODE_SIGNING_ALLOWED=NO` from the CI build flags
- Without proper ad-hoc signing, macOS silently blocks `Process` subprocess execution, which prevents the CLI version check from running
- This was the root cause of the version check section not appearing in brew-installed builds (while locally-built versions worked fine)
- Keeping `CODE_SIGN_IDENTITY="-"` for proper ad-hoc signing with sealed resources

## Test plan
- [ ] Create a release after merge
- [ ] Install from brew (`brew upgrade --cask dmelo/tap/claude-code-stats`)
- [ ] Open the menu bar popover — version line should appear below usage cards
- [ ] Verify with `codesign -dv /Applications/ClaudeCodeStats.app` that `Info.plist entries` and `Sealed Resources` are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)