### PR TITLE
Add light/dark theme support

### DIFF
--- a/ClaudeCodeStats/ClaudeCodeStats/ContentView.swift
+++ b/ClaudeCodeStats/ClaudeCodeStats/ContentView.swift
@@ -25,11 +25,11 @@ struct ContentView: View {
             HStack {
                 Image(systemName: "chart.bar.fill")
                     .font(.system(size: 14))
-                    .foregroundColor(.white)
+                    .foregroundColor(Theme.textPrimary)
 
                 Text("Claude Code Stats")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.white)
+                    .foregroundColor(Theme.textPrimary)
 
                 Spacer()
 

--- a/ClaudeCodeStats/ClaudeCodeStats/Theme.swift
+++ b/ClaudeCodeStats/ClaudeCodeStats/Theme.swift
@@ -1,9 +1,40 @@
 import SwiftUI
+import AppKit
 
 enum Theme {
-    static let background = Color(red: 26/255, green: 26/255, blue: 26/255)
-    static let cardBackground = Color(red: 42/255, green: 42/255, blue: 42/255)
-    static let textSecondary = Color(red: 138/255, green: 138/255, blue: 138/255)
-    static let divider = Color(red: 58/255, green: 58/255, blue: 58/255)
-    static let inputBackground = Color(red: 35/255, green: 35/255, blue: 35/255)
+    static let background = Color(nsColor: NSColor(name: nil, dynamicProvider: { appearance in
+        appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+            ? NSColor(red: 26/255, green: 26/255, blue: 26/255, alpha: 1)
+            : NSColor(red: 245/255, green: 245/255, blue: 245/255, alpha: 1)
+    }))
+
+    static let cardBackground = Color(nsColor: NSColor(name: nil, dynamicProvider: { appearance in
+        appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+            ? NSColor(red: 42/255, green: 42/255, blue: 42/255, alpha: 1)
+            : NSColor(red: 255/255, green: 255/255, blue: 255/255, alpha: 1)
+    }))
+
+    static let textPrimary = Color(nsColor: NSColor(name: nil, dynamicProvider: { appearance in
+        appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+            ? NSColor(red: 255/255, green: 255/255, blue: 255/255, alpha: 1)
+            : NSColor(red: 0/255, green: 0/255, blue: 0/255, alpha: 1)
+    }))
+
+    static let textSecondary = Color(nsColor: NSColor(name: nil, dynamicProvider: { appearance in
+        appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+            ? NSColor(red: 138/255, green: 138/255, blue: 138/255, alpha: 1)
+            : NSColor(red: 102/255, green: 102/255, blue: 102/255, alpha: 1)
+    }))
+
+    static let divider = Color(nsColor: NSColor(name: nil, dynamicProvider: { appearance in
+        appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+            ? NSColor(red: 58/255, green: 58/255, blue: 58/255, alpha: 1)
+            : NSColor(red: 224/255, green: 224/255, blue: 224/255, alpha: 1)
+    }))
+
+    static let inputBackground = Color(nsColor: NSColor(name: nil, dynamicProvider: { appearance in
+        appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+            ? NSColor(red: 35/255, green: 35/255, blue: 35/255, alpha: 1)
+            : NSColor(red: 235/255, green: 235/255, blue: 235/255, alpha: 1)
+    }))
 }

--- a/ClaudeCodeStats/ClaudeCodeStats/Views/SettingsView.swift
+++ b/ClaudeCodeStats/ClaudeCodeStats/Views/SettingsView.swift
@@ -16,13 +16,13 @@ struct SettingsView: View {
                 Button(action: { isPresented = false }) {
                     Image(systemName: "chevron.left")
                         .font(.system(size: 12))
-                        .foregroundColor(.white)
+                        .foregroundColor(Theme.textPrimary)
                 }
                 .buttonStyle(.plain)
 
                 Text("Settings")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.white)
+                    .foregroundColor(Theme.textPrimary)
 
                 Spacer()
             }
@@ -39,7 +39,7 @@ struct SettingsView: View {
                         HStack {
                             Text("Session Cookie")
                                 .font(.system(size: 12, weight: .medium))
-                                .foregroundColor(.white)
+                                .foregroundColor(Theme.textPrimary)
 
                             Spacer()
 
@@ -57,7 +57,7 @@ struct SettingsView: View {
                             .padding(8)
                             .background(Theme.cardBackground)
                             .cornerRadius(6)
-                            .foregroundColor(.white)
+                            .foregroundColor(Theme.textPrimary)
 
                         if showingInstructions {
                             instructionsView
@@ -97,7 +97,7 @@ struct SettingsView: View {
                             HStack {
                                 Text("Cloudflare Bypass")
                                     .font(.system(size: 12, weight: .medium))
-                                    .foregroundColor(.white)
+                                    .foregroundColor(Theme.textPrimary)
 
                                 Spacer()
 
@@ -120,7 +120,7 @@ struct SettingsView: View {
                                 .padding(8)
                                 .background(Theme.inputBackground)
                                 .cornerRadius(6)
-                                .foregroundColor(.white)
+                                .foregroundColor(Theme.textPrimary)
 
                             advancedInstructionsView
 
@@ -202,7 +202,7 @@ struct SettingsView: View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Menu Bar Display")
                 .font(.system(size: 12, weight: .medium))
-                .foregroundColor(.white)
+                .foregroundColor(Theme.textPrimary)
 
             Toggle("Show session usage", isOn: $showSession)
                 .font(.system(size: 11))
@@ -225,7 +225,7 @@ struct SettingsView: View {
         VStack(alignment: .leading, spacing: 6) {
             Text("To get your session cookie:")
                 .font(.system(size: 11, weight: .medium))
-                .foregroundColor(.white)
+                .foregroundColor(Theme.textPrimary)
 
             Group {
                 Text("1. Open claude.ai in your browser")
@@ -250,7 +250,7 @@ struct SettingsView: View {
         VStack(alignment: .leading, spacing: 4) {
             Text("How to get full cookies:")
                 .font(.system(size: 10, weight: .medium))
-                .foregroundColor(.white)
+                .foregroundColor(Theme.textPrimary)
 
             Group {
                 Text("1. Open claude.ai/settings/usage")

--- a/ClaudeCodeStats/ClaudeCodeStats/Views/UsageCardView.swift
+++ b/ClaudeCodeStats/ClaudeCodeStats/Views/UsageCardView.swift
@@ -31,14 +31,14 @@ struct UsageCardView: View {
         VStack(alignment: .leading, spacing: 8) {
             Text(title)
                 .font(.system(size: 13, weight: .medium))
-                .foregroundColor(.white)
+                .foregroundColor(Theme.textPrimary)
 
             HStack(spacing: 12) {
                 ProgressBarView(progress: usage)
 
                 Text("\(Int(usage))%")
                     .font(.system(size: 12, weight: .semibold, design: .monospaced))
-                    .foregroundColor(.white)
+                    .foregroundColor(Theme.textPrimary)
                     .frame(width: 40, alignment: .trailing)
             }
 


### PR DESCRIPTION
## Summary
- Replace static dark-only colors in `Theme.swift` with `NSColor(name:dynamicProvider:)` that automatically adapts to macOS appearance
- Add `Theme.textPrimary` (white in dark mode, black in light mode) and replace hardcoded `.white` foreground colors across views
- Light variants: light gray background, white cards, darker secondary text, light dividers and input fields

## Test plan
- [x] Build and launch the app
- [x] Verify dark mode looks identical to before
- [x] Switch macOS to light mode (System Settings → Appearance) and verify the popup adapts
- [x] Switch back to dark mode and verify it reverts
- [x] Check Settings view in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)