### PR TITLE
Cache OAuth token in app-owned Keychain

### DIFF
--- a/ClaudeCodeStats/ClaudeCodeStats/Services/OAuthUsageService.swift
+++ b/ClaudeCodeStats/ClaudeCodeStats/Services/OAuthUsageService.swift
@@ -12,15 +12,13 @@ class OAuthUsageService {
     }()
     private let keychainService = "Claude Code-credentials"
     private let appKeychainService = "ClaudeCodeStats-credentials"
+    private let appKeychainAccount = "oauth-token"
     private var cachedToken: String?
 
     private init() {}
 
     var hasCredentials: Bool {
-        cachedToken != nil
-            || readTokenFromFile() != nil
-            || readTokenFromAppKeychain() != nil
-            || readTokenFromKeychain(service: keychainService) != nil
+        readAccessToken() != nil
     }
 
     func fetchUsage() async throws -> WebUsageData {
@@ -109,6 +107,7 @@ class OAuthUsageService {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: appKeychainService,
+            kSecAttrAccount as String: appKeychainAccount,
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne
         ]
@@ -153,6 +152,7 @@ class OAuthUsageService {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: appKeychainService,
+            kSecAttrAccount as String: appKeychainAccount,
             kSecValueData as String: data
         ]
         let status = SecItemAdd(query as CFDictionary, nil)
@@ -164,7 +164,8 @@ class OAuthUsageService {
     private func deleteAppKeychainItem() {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: appKeychainService
+            kSecAttrService as String: appKeychainService,
+            kSecAttrAccount as String: appKeychainAccount
         ]
         let status = SecItemDelete(query as CFDictionary)
         if status != errSecSuccess && status != errSecItemNotFound {

--- a/ClaudeCodeStats/ClaudeCodeStats/Services/OAuthUsageService.swift
+++ b/ClaudeCodeStats/ClaudeCodeStats/Services/OAuthUsageService.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Security
 
+@MainActor
 class OAuthUsageService {
     static let shared = OAuthUsageService()
 
@@ -16,7 +17,10 @@ class OAuthUsageService {
     private init() {}
 
     var hasCredentials: Bool {
-        readAccessToken() != nil
+        cachedToken != nil
+            || readTokenFromFile() != nil
+            || readTokenFromAppKeychain() != nil
+            || readTokenFromKeychain(service: keychainService) != nil
     }
 
     func fetchUsage() async throws -> WebUsageData {
@@ -100,6 +104,7 @@ class OAuthUsageService {
         return token
     }
 
+    // App keychain stores the raw token string, not the JSON credential blob
     private func readTokenFromAppKeychain() -> String? {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
@@ -150,7 +155,10 @@ class OAuthUsageService {
             kSecAttrService as String: appKeychainService,
             kSecValueData as String: data
         ]
-        SecItemAdd(query as CFDictionary, nil)
+        let status = SecItemAdd(query as CFDictionary, nil)
+        if status != errSecSuccess {
+            NSLog("OAuthUsageService: Failed to cache token in app keychain (status: \(status))")
+        }
     }
 
     private func deleteAppKeychainItem() {
@@ -158,7 +166,10 @@ class OAuthUsageService {
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: appKeychainService
         ]
-        SecItemDelete(query as CFDictionary)
+        let status = SecItemDelete(query as CFDictionary)
+        if status != errSecSuccess && status != errSecItemNotFound {
+            NSLog("OAuthUsageService: Failed to delete app keychain item (status: \(status))")
+        }
     }
 
     private func extractToken(from data: Data) -> String? {

--- a/ClaudeCodeStats/ClaudeCodeStats/Services/OAuthUsageService.swift
+++ b/ClaudeCodeStats/ClaudeCodeStats/Services/OAuthUsageService.swift
@@ -10,6 +10,8 @@ class OAuthUsageService {
         return "\(home)/.claude/.credentials.json"
     }()
     private let keychainService = "Claude Code-credentials"
+    private let appKeychainService = "ClaudeCodeStats-credentials"
+    private var cachedToken: String?
 
     private init() {}
 
@@ -53,6 +55,7 @@ class OAuthUsageService {
         }
 
         if httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
+            clearCachedToken()
             throw UsageError.tokenExpired
         }
 
@@ -65,10 +68,28 @@ class OAuthUsageService {
     }
 
     private func readAccessToken() -> String? {
-        if let token = readTokenFromFile() {
+        if let token = cachedToken {
             return token
         }
-        return readTokenFromKeychain()
+        if let token = readTokenFromFile() {
+            cachedToken = token
+            return token
+        }
+        if let token = readTokenFromAppKeychain() {
+            cachedToken = token
+            return token
+        }
+        if let token = readTokenFromKeychain(service: keychainService) {
+            saveTokenToAppKeychain(token)
+            cachedToken = token
+            return token
+        }
+        return nil
+    }
+
+    private func clearCachedToken() {
+        cachedToken = nil
+        deleteAppKeychainItem()
     }
 
     private func readTokenFromFile() -> String? {
@@ -79,10 +100,30 @@ class OAuthUsageService {
         return token
     }
 
-    private func readTokenFromKeychain() -> String? {
+    private func readTokenFromAppKeychain() -> String? {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: keychainService,
+            kSecAttrService as String: appKeychainService,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess,
+              let data = result as? Data,
+              let token = String(data: data, encoding: .utf8),
+              !token.isEmpty else {
+            return nil
+        }
+        return token
+    }
+
+    private func readTokenFromKeychain(service: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne
         ]
@@ -96,6 +137,28 @@ class OAuthUsageService {
             return nil
         }
         return token
+    }
+
+    private func saveTokenToAppKeychain(_ token: String) {
+        guard let data = token.data(using: .utf8) else { return }
+
+        // Delete existing item first (if any)
+        deleteAppKeychainItem()
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: appKeychainService,
+            kSecValueData as String: data
+        ]
+        SecItemAdd(query as CFDictionary, nil)
+    }
+
+    private func deleteAppKeychainItem() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: appKeychainService
+        ]
+        SecItemDelete(query as CFDictionary)
     }
 
     private func extractToken(from data: Data) -> String? {

--- a/ClaudeCodeStats/ClaudeCodeStats/Services/OAuthUsageService.swift
+++ b/ClaudeCodeStats/ClaudeCodeStats/Services/OAuthUsageService.swift
@@ -57,7 +57,7 @@ class OAuthUsageService {
         }
 
         if httpResponse.statusCode == 401 || httpResponse.statusCode == 403 {
-            clearCachedToken()
+            clearTokenCaches()
             throw UsageError.tokenExpired
         }
 
@@ -89,7 +89,7 @@ class OAuthUsageService {
         return nil
     }
 
-    private func clearCachedToken() {
+    private func clearTokenCaches() {
         cachedToken = nil
         deleteAppKeychainItem()
     }
@@ -153,7 +153,8 @@ class OAuthUsageService {
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: appKeychainService,
             kSecAttrAccount as String: appKeychainAccount,
-            kSecValueData as String: data
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
         ]
         let status = SecItemAdd(query as CFDictionary, nil)
         if status != errSecSuccess {


### PR DESCRIPTION
## Summary
- Cache the extracted OAuth access token in a `ClaudeCodeStats-credentials` Keychain item owned by the app, avoiding repeated macOS authorization prompts from reading Claude Code's Keychain item
- Add in-memory token cache to skip all I/O on subsequent polls within the same session
- Invalidate both caches on 401/403 so the next fetch re-reads from the source

## Test plan
- [x] Build and install locally
- [ ] Verify first launch reads from Claude Code's Keychain (one-time prompt) and caches to app Keychain
- [ ] Verify subsequent polls use cached token with no prompt
- [ ] Verify 401/403 clears cache and re-prompts on next fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)