### PR TITLE
Fix stale session reset countdown

### DIFF
--- a/ClaudeCodeStats/ClaudeCodeStats/ContentView.swift
+++ b/ClaudeCodeStats/ClaudeCodeStats/ContentView.swift
@@ -6,6 +6,12 @@ struct ContentView: View {
     @State private var showingSettings = false
     @State private var isSpinning = false
 
+    private static let lastUpdatedTimeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        return formatter
+    }()
+
     var body: some View {
         if showingSettings {
             SettingsView(isPresented: $showingSettings)
@@ -161,7 +167,7 @@ struct ContentView: View {
 
     private var footerView: some View {
         HStack {
-            TimelineView(.periodic(from: .now, by: 30)) { context in
+            TimelineView(.everyMinute) { context in
                 Text(lastUpdatedString(at: context.date))
                     .font(.system(size: 10))
                     .foregroundColor(Theme.textSecondary)
@@ -278,9 +284,7 @@ struct ContentView: View {
             let minutes = Int(interval / 60)
             return "Updated \(minutes)m ago"
         } else {
-            let formatter = DateFormatter()
-            formatter.timeStyle = .short
-            return "Updated at \(formatter.string(from: lastUpdated))"
+            return "Updated at \(Self.lastUpdatedTimeFormatter.string(from: lastUpdated))"
         }
     }
 }

--- a/ClaudeCodeStats/ClaudeCodeStats/ContentView.swift
+++ b/ClaudeCodeStats/ClaudeCodeStats/ContentView.swift
@@ -161,9 +161,11 @@ struct ContentView: View {
 
     private var footerView: some View {
         HStack {
-            Text(lastUpdatedString)
-                .font(.system(size: 10))
-                .foregroundColor(Theme.textSecondary)
+            TimelineView(.periodic(from: .now, by: 30)) { context in
+                Text(lastUpdatedString(at: context.date))
+                    .font(.system(size: 10))
+                    .foregroundColor(Theme.textSecondary)
+            }
 
             Spacer()
 
@@ -264,12 +266,12 @@ struct ContentView: View {
         .padding(.vertical, 8)
     }
 
-    private var lastUpdatedString: String {
+    private func lastUpdatedString(at now: Date) -> String {
         guard let lastUpdated = viewModel.webUsage?.lastUpdated else {
             return "Not yet updated"
         }
 
-        let interval = Date().timeIntervalSince(lastUpdated)
+        let interval = now.timeIntervalSince(lastUpdated)
         if interval < 60 {
             return "Updated just now"
         } else if interval < 3600 {

--- a/ClaudeCodeStats/ClaudeCodeStats/Views/UsageCardView.swift
+++ b/ClaudeCodeStats/ClaudeCodeStats/Views/UsageCardView.swift
@@ -5,6 +5,12 @@ struct UsageCardView: View {
     let usage: Double
     let resetsAt: Date
 
+    private static let resetDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "EEE h:mm a"
+        return formatter
+    }()
+
     private func resetTimeString(at now: Date) -> String {
         let interval = resetsAt.timeIntervalSince(now)
 
@@ -16,9 +22,7 @@ struct UsageCardView: View {
         let minutes = (Int(interval) % 3600) / 60
 
         if hours > 24 {
-            let formatter = DateFormatter()
-            formatter.dateFormat = "EEE h:mm a"
-            return "Resets \(formatter.string(from: resetsAt))"
+            return "Resets \(Self.resetDateFormatter.string(from: resetsAt))"
         } else if hours > 0 {
             return "Resets in \(hours)h \(minutes)m"
         } else {
@@ -41,7 +45,7 @@ struct UsageCardView: View {
                     .frame(width: 40, alignment: .trailing)
             }
 
-            TimelineView(.periodic(from: .now, by: 30)) { context in
+            TimelineView(.everyMinute) { context in
                 Text(resetTimeString(at: context.date))
                     .font(.system(size: 11))
                     .foregroundColor(Theme.textSecondary)

--- a/ClaudeCodeStats/ClaudeCodeStats/Views/UsageCardView.swift
+++ b/ClaudeCodeStats/ClaudeCodeStats/Views/UsageCardView.swift
@@ -5,8 +5,7 @@ struct UsageCardView: View {
     let usage: Double
     let resetsAt: Date
 
-    private var resetTimeString: String {
-        let now = Date()
+    private func resetTimeString(at now: Date) -> String {
         let interval = resetsAt.timeIntervalSince(now)
 
         if interval <= 0 {
@@ -42,9 +41,11 @@ struct UsageCardView: View {
                     .frame(width: 40, alignment: .trailing)
             }
 
-            Text(resetTimeString)
-                .font(.system(size: 11))
-                .foregroundColor(Theme.textSecondary)
+            TimelineView(.periodic(from: .now, by: 30)) { context in
+                Text(resetTimeString(at: context.date))
+                    .font(.system(size: 11))
+                    .foregroundColor(Theme.textSecondary)
+            }
         }
         .padding(12)
         .background(Theme.cardBackground)


### PR DESCRIPTION
## Summary
- update the session reset label to use `TimelineView` so the countdown keeps advancing while the popover stays open
- update the footer's `last updated` text the same way so it stays in sync with the live countdown
- verify the fix with `xcodebuild -scheme ClaudeCodeStats -configuration Release build`