### PR TITLE
Add Opus 5 to the cost price table

### DIFF
--- a/ClaudeCodeStats/ClaudeCodeStats/Services/CostService.swift
+++ b/ClaudeCodeStats/ClaudeCodeStats/Services/CostService.swift
@@ -46,6 +46,7 @@ private let sonnet5IntroEnds: Date = {
 // missing from this table is skipped, which is also how the synthetic entries
 // Claude Code writes for local errors ("<synthetic>") stay out of the total.
 private let priceTable: [(prefix: String, price: ModelPrice)] = [
+    ("claude-opus-5", ModelPrice(display: "Opus 5", standard: Rate(input: 5, output: 25))),
     ("claude-opus-4-8", ModelPrice(display: "Opus 4.8", standard: Rate(input: 5, output: 25))),
     ("claude-opus-4-7", ModelPrice(display: "Opus 4.7", standard: Rate(input: 5, output: 25))),
     ("claude-opus-4-6", ModelPrice(display: "Opus 4.6", standard: Rate(input: 5, output: 25))),
@@ -91,7 +92,10 @@ private let chartWindowDays = 30
 /// so the corpus-wide ratio needs one full re-scan to be representative.
 /// 7: count those totals once per unique entry instead of per scanned copy, so a
 /// whole-file re-read (the shrink path) can't inflate them; re-scan to rebuild.
-private let cacheVersion = 7
+/// 8: added Opus 5 to the price table. It shipped as a new prefix the table had
+/// never seen, so every Opus 5 entry was skipped outright rather than mispriced —
+/// silently omitting the model from spend since it started being used.
+private let cacheVersion = 8
 
 private struct EntryCost: Codable {
     let model: String


### PR DESCRIPTION
## The bug

`CostService`'s `priceTable` had no entry for `claude-opus-5`. `price(for:)` matches by prefix and returns `nil` for anything unlisted, so `ingest` dropped every Opus 5 entry — the same path that intentionally keeps `<synthetic>` entries out of the total. Opus 5 spend wasn't mispriced, it was **counted as zero** from the day it started being used (2026-07-24 in this corpus).

Measured against `npx ccusage` at the same instant:

| | widget | ccusage | delta |
|---|---|---|---|
| Today | $7.16 | $45.75 | $38.59 |
| Last 7 days | $975.86 | $1,144.74 | $168.88 |
| Month to date | $6,319.63 | $6,488.44 | $168.81 |

Those deltas are exactly ccusage's Opus 5 totals for the same spans. The 7-day and month-to-date gaps being identical was the tell: the entire discrepancy sat in days that fall in both windows, i.e. one model missing outright rather than a rate being wrong. Older days were always correct because Opus 5 doesn't appear in them.

## The fix

- Added `claude-opus-5` at $5/$25 per Mtok — same as Opus 4.8, and the 1M context window carries no long-context premium.
- Bumped `cacheVersion` 7 → 8. Required: costs are priced once at scan time and offsets advance regardless, so without it the cached zeros would survive.

## Verification

Cold rescan, then per-day comparison against ccusage. Every completed day Jul 1–27 now agrees **to the cent** ($0.07 across the whole month, on the `--since` boundary day). Today shows −$0.64 purely because ccusage ran ~2 min after the app's snapshot and the corpus is live — the measurement skew documented in CLAUDE.md, not a residual. Opus 5 now appears in the per-model breakdown.

## Follow-ups (not in this PR)

- **This recurs on every model launch.** An unpriced model is silently dropped rather than flagged, so the failure mode is a quiet undercount that only surfaces if you happen to diff against ccusage. Worth surfacing unpriced prefixes somewhere.
- **Fast mode would undercount 2×.** Opus 5 fast mode bills at $10/$50. The transcripts do carry a `speed` field — currently `"standard"` on all 83,527 entries, so no impact today, but pricing it would need the field read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)