### PR TITLE
Fix Settings panel clipped inside oversized popover

### DIFF
--- a/ClaudeCodeStats/ClaudeCodeStats/Views/SettingsView.swift
+++ b/ClaudeCodeStats/ClaudeCodeStats/Views/SettingsView.swift
@@ -14,15 +14,18 @@ struct SettingsView: View {
             Divider()
                 .background(Theme.divider)
 
-            ScrollView {
-                VStack(alignment: .leading, spacing: 16) {
-                    authStatusSection
-                    appearanceSection
-                    menuBarDisplaySection
-                    versionRow
-                }
-                .padding(12)
+            // A plain VStack, not a ScrollView: inside MenuBarExtra(.window) a
+            // ScrollView reports an indefinite fitting height, so the popover
+            // keeps the taller main-view height while the scroll content
+            // collapses and clips (issue #25). The settings content is short
+            // enough to always fit, so let it size the window naturally.
+            VStack(alignment: .leading, spacing: 16) {
+                authStatusSection
+                appearanceSection
+                menuBarDisplaySection
+                versionRow
             }
+            .padding(12)
         }
         .frame(width: 280)
         .background(Theme.background)


### PR DESCRIPTION
Fixes #25.

## Problem

Opening Settings drew the panel as a small box floating inside a much taller, mostly empty popover, with the bottom of the panel clipped — "Show Fable usage" and the version row were hidden unless you scrolled.

## Root cause

`SettingsView` wrapped its content in a `ScrollView`, left over from the initial commit when Settings held a session-key input and long instructions. Inside `MenuBarExtra(.window)` the popover auto-sizes to its content's fitting height, but a `ScrollView` reports an *indefinite* fitting height. So when switching from the taller main view to Settings, the window kept the main view's height while the `ScrollView` collapsed smaller than its own content — producing the oversized-empty-popover + clipped-box symptom. The main view never hit this because it's a plain `VStack` with a definite height.

## Fix

Drop the `ScrollView` and let the `VStack` size the window naturally. The Settings content is ~380px tall — far shorter than the main view and any screen — so scrolling was never needed.

## Verification

Reproduced the bug on the exact released artifact (0.10.1 downloaded from the GitHub release, the same build Homebrew ships and the reporter has): oversized popover, clipped Menu Bar Display card, stranded version label.

Rebuilt with this change and confirmed on the same machine (macOS 26.6, Apple silicon): the popover shrinks to fit Settings exactly — all three Menu Bar Display toggles and the version row fully visible, no empty space, no scrolling.
