### PR TITLE
Resize Settings popover to fit its content (follow-up to #26)

### DIFF
--- a/ClaudeCodeStats/ClaudeCodeStats/ContentView.swift
+++ b/ClaudeCodeStats/ClaudeCodeStats/ContentView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 
 struct ContentView: View {
     @EnvironmentObject var viewModel: UsageViewModel
@@ -13,16 +14,28 @@ struct ContentView: View {
     }()
 
     var body: some View {
-        if showingSettings {
-            SettingsView(isPresented: $showingSettings)
-                .onChange(of: showingSettings) { _, newValue in
-                    if !newValue {
-                        Task { await viewModel.refresh() }
+        Group {
+            if showingSettings {
+                SettingsView(isPresented: $showingSettings)
+                    .onChange(of: showingSettings) { _, newValue in
+                        if !newValue {
+                            Task { await viewModel.refresh() }
+                        }
                     }
-                }
-        } else {
-            mainView
+            } else {
+                mainView
+            }
         }
+        // MenuBarExtra(.window) sizes the popover to whatever it shows first
+        // (always the taller main view) and won't shrink it when we swap to the
+        // compact Settings view — stranding Settings, centered, in an oversized
+        // panel with empty space above and below (issue #25). Measure the live
+        // content height and nudge the panel to match it on every swap.
+        .background(
+            GeometryReader { proxy in
+                WindowFitter(targetHeight: proxy.size.height)
+            }
+        )
     }
 
     private var mainView: some View {
@@ -324,6 +337,36 @@ struct ContentView: View {
             return "Updated \(minutes)m ago"
         } else {
             return "Updated at \(Self.lastUpdatedTimeFormatter.string(from: lastUpdated))"
+        }
+    }
+}
+
+/// Resizes the hosting MenuBarExtra panel to a target content height, keeping
+/// its top edge anchored under the menu bar. Works around MenuBarExtra(.window)
+/// not shrinking its panel when the SwiftUI content becomes shorter (e.g. main
+/// view → Settings). `targetHeight` comes from a GeometryReader measuring the
+/// live content, so it reflects the ideal height of whichever view is showing.
+private struct WindowFitter: NSViewRepresentable {
+    var targetHeight: CGFloat
+
+    func makeNSView(context: Context) -> NSView { NSView() }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        let height = targetHeight
+        guard height > 1 else { return }
+        // Defer to the next runloop tick so the panel exists and AppKit has
+        // finished the current layout pass before we override the frame.
+        DispatchQueue.main.async {
+            guard let window = nsView.window else { return }
+            let frame = window.frame
+            guard abs(frame.height - height) > 0.5 else { return }
+            window.setFrame(
+                NSRect(x: frame.origin.x,
+                       y: frame.maxY - height,
+                       width: frame.width,
+                       height: height),
+                display: true
+            )
         }
     }
 }

--- a/ClaudeCodeStats/ClaudeCodeStats/ContentView.swift
+++ b/ClaudeCodeStats/ClaudeCodeStats/ContentView.swift
@@ -353,11 +353,17 @@ private struct WindowFitter: NSViewRepresentable {
 
     func updateNSView(_ nsView: NSView, context: Context) {
         let height = targetHeight
-        guard height > 1 else { return }
-        // Defer to the next runloop tick so the panel exists and AppKit has
-        // finished the current layout pass before we override the frame.
-        DispatchQueue.main.async {
-            guard let window = nsView.window else { return }
+        // updateNSView runs on the main thread, so check the live panel height
+        // synchronously and bail before scheduling anything when it already
+        // matches — otherwise a stable popover enqueues a redundant block on
+        // every SwiftUI layout pass.
+        guard height > 1, let window = nsView.window,
+              abs(window.frame.height - height) > 0.5 else { return }
+        // Defer only the actual setFrame to the next runloop tick so we don't
+        // mutate the panel mid-SwiftUI-update; weak-capture the window so a
+        // torn-down popover isn't retained past teardown.
+        DispatchQueue.main.async { [weak window] in
+            guard let window else { return }
             let frame = window.frame
             guard abs(frame.height - height) > 0.5 else { return }
             window.setFrame(


### PR DESCRIPTION
Fixes #25. Follow-up to #26, which was an incomplete fix.

## Why #26 wasn't enough

#26 removed the `ScrollView`, which stopped the Settings content from *clipping* — but the panel was still oversized. The real cause is that `MenuBarExtra(.window)` sizes the popover to whatever it shows first (always the taller main view) and never shrinks it. Swapping to the shorter Settings view left it centered in an oversized panel with empty space above and below.

The amount of empty space scaled with how much taller the main view was than Settings, which is why it only became obvious once the spend/RTK cards had finished their background scan — a short (still-loading) main view masked it.

## Fix

A `GeometryReader` measures the live content height (the ideal height of whichever view is showing), and `WindowFitter` drives the hosting panel's frame to match on every swap, keeping the panel's top edge anchored under the menu bar. When you switch to Settings the panel shrinks to fit; switching back grows it to the main view again.

## Verification

Built and tested on macOS 26.6 (Apple silicon) in the failing condition — popover opened and fully loaded so the main view was tall (session + weekly + Fable + spend + RTK), *then* opened Settings:

- Settings now sizes exactly to its content — no empty space above or below, bottom edge at the version row.
- Back-chevron returns to the full-height main view correctly.
- Stable across repeated open / toggle cycles, no flicker or detaching from the menu bar.
