### PR TITLE
Switch spend & savings cards from month-to-date to a rolling 30-day window

### DIFF
--- a/ClaudeCodeStats/ClaudeCodeStats/Models.swift
+++ b/ClaudeCodeStats/ClaudeCodeStats/Models.swift
@@ -99,7 +99,7 @@ extension Double {
 struct RTKSavings {
     let todaySaved: Int
     let weekSaved: Int
-    let monthSaved: Int
+    let last30Saved: Int
     let lifetimeSaved: Int
     /// Raw pre-filter tokens across all routed commands — the denominator for the
     /// average reduction. This is what RTK calls "input": the command's full
@@ -133,10 +133,10 @@ struct RTKSavings {
     // re-billing it would have incurred unfiltered. Truth sits between.
     var todayFloor: Double { Double(todaySaved) / 1_000_000 * inputRate }
     var weekFloor: Double { Double(weekSaved) / 1_000_000 * inputRate }
-    var monthFloor: Double { Double(monthSaved) / 1_000_000 * inputRate }
+    var last30Floor: Double { Double(last30Saved) / 1_000_000 * inputRate }
     var todayCeiling: Double { todayFloor * ceilingMultiplier }
     var weekCeiling: Double { weekFloor * ceilingMultiplier }
-    var monthCeiling: Double { monthFloor * ceilingMultiplier }
+    var last30Ceiling: Double { last30Floor * ceilingMultiplier }
 }
 
 extension Int {
@@ -173,8 +173,8 @@ struct DailySpend: Identifiable {
 struct SpendData {
     let today: Double
     let week: Double
-    let month: Double
-    let monthByModel: [ModelSpend]
+    let last30: Double
+    let last30ByModel: [ModelSpend]
     /// Rolling window ending today, oldest first.
     let daily: [DailySpend]
     let lastUpdated: Date

--- a/ClaudeCodeStats/ClaudeCodeStats/Services/CostService.swift
+++ b/ClaudeCodeStats/ClaudeCodeStats/Services/CostService.swift
@@ -73,7 +73,8 @@ private let cacheWrite5mMultiplier = 1.25
 private let cacheWrite1hMultiplier = 2.00
 
 /// Day rollups older than this are dropped from the cache. Must exceed the
-/// longest window we report (month-to-date, and the chart) with room to spare.
+/// longest window we report (the last-30-days total and the chart, both
+/// `chartWindowDays`) with room to spare.
 private let retentionDays = 100
 
 /// Days of history the chart plots, counting back from today.
@@ -411,12 +412,14 @@ actor CostService {
         let calendar = Calendar.current
         let today = calendar.startOfDay(for: Date())
         let weekStart = calendar.date(byAdding: .day, value: -6, to: today) ?? today
-        let monthStart = calendar.date(from: calendar.dateComponents([.year, .month], from: today)) ?? today
+        // Rolling 30-day window, sharing the chart's span so the "Last 30 days"
+        // total is exactly the sum of the bars plotted below it.
+        let last30Start = calendar.date(byAdding: .day, value: -(chartWindowDays - 1), to: today) ?? today
 
         var todayTotal = 0.0
         var weekTotal = 0.0
-        var monthTotal = 0.0
-        var monthByModel: [String: Double] = [:]
+        var last30Total = 0.0
+        var last30ByModel: [String: Double] = [:]
         var totalByDay: [String: Double] = [:]
 
         for (day, rollup) in cache.days {
@@ -426,9 +429,9 @@ actor CostService {
                 totalByDay[day, default: 0] += entry.cost
                 if date >= today { todayTotal += entry.cost }
                 if date >= weekStart { weekTotal += entry.cost }
-                if date >= monthStart {
-                    monthTotal += entry.cost
-                    monthByModel[entry.model, default: 0] += entry.cost
+                if date >= last30Start {
+                    last30Total += entry.cost
+                    last30ByModel[entry.model, default: 0] += entry.cost
                 }
             }
         }
@@ -445,8 +448,8 @@ actor CostService {
         return SpendData(
             today: todayTotal,
             week: weekTotal,
-            month: monthTotal,
-            monthByModel: monthByModel
+            last30: last30Total,
+            last30ByModel: last30ByModel
                 .map { ModelSpend(model: $0.key, cost: $0.value) }
                 .sorted { $0.cost > $1.cost },
             daily: daily,

--- a/ClaudeCodeStats/ClaudeCodeStats/Services/RTKSavingsService.swift
+++ b/ClaudeCodeStats/ClaudeCodeStats/Services/RTKSavingsService.swift
@@ -28,7 +28,7 @@ actor RTKSavingsService {
         FileManager.default.fileExists(atPath: dbPath)
     }
 
-    /// Rolls up saved tokens over today / last 7 days / month-to-date plus a
+    /// Rolls up saved tokens over today / last 7 days / last 30 days plus a
     /// lifetime total. Returns `nil` when RTK isn't installed, the database can't
     /// be read, or it holds no commands yet — all of which just hide the card.
     func fetch() async -> RTKSavings? {
@@ -54,7 +54,7 @@ actor RTKSavingsService {
         // Wait out a transient writer lock rather than failing the whole refresh.
         sqlite3_busy_timeout(db, 2000)
 
-        let (today, week, month) = Self.windowBoundaries()
+        let (today, week, last30) = Self.windowBoundaries()
 
         // Timestamps are stored as UTC ISO8601 with a `+00:00` suffix and
         // microsecond precision. Comparing the first 19 characters
@@ -83,7 +83,7 @@ actor RTKSavingsService {
 
         sqlite3_bind_text(stmt, 1, today, -1, Self.transient)
         sqlite3_bind_text(stmt, 2, week, -1, Self.transient)
-        sqlite3_bind_text(stmt, 3, month, -1, Self.transient)
+        sqlite3_bind_text(stmt, 3, last30, -1, Self.transient)
 
         guard sqlite3_step(stmt) == SQLITE_ROW else { return nil }
 
@@ -103,7 +103,7 @@ actor RTKSavingsService {
         return RTKSavings(
             todaySaved: nonNegative(0),
             weekSaved: nonNegative(1),
-            monthSaved: nonNegative(2),
+            last30Saved: nonNegative(2),
             lifetimeSaved: nonNegative(3),
             lifetimeRaw: nonNegative(4),
             commandCount: count,
@@ -118,13 +118,14 @@ actor RTKSavingsService {
     /// Boundaries are computed in the user's local calendar (a "day" here means
     /// their local day, not the UTC day RTK stamps) and rendered as
     /// UTC-to-the-second strings to compare against the stored timestamps. Mirrors
-    /// CostService's windows: "last 7 days" is today plus the six days before it.
-    private static func windowBoundaries() -> (today: String, week: String, month: String) {
+    /// CostService's windows: "last 7 days" is today plus the six days before it,
+    /// "last 30 days" today plus the 29 before it.
+    private static func windowBoundaries() -> (today: String, week: String, last30: String) {
         let calendar = Calendar.current
         let today = calendar.startOfDay(for: Date())
         let week = calendar.date(byAdding: .day, value: -6, to: today) ?? today
-        let month = calendar.date(from: calendar.dateComponents([.year, .month], from: today)) ?? today
-        return (boundary(today), boundary(week), boundary(month))
+        let last30 = calendar.date(byAdding: .day, value: -29, to: today) ?? today
+        return (boundary(today), boundary(week), boundary(last30))
     }
 
     private static let boundaryFormatter: DateFormatter = {

--- a/ClaudeCodeStats/ClaudeCodeStats/Views/RTKSavingsCardView.swift
+++ b/ClaudeCodeStats/ClaudeCodeStats/Views/RTKSavingsCardView.swift
@@ -18,7 +18,7 @@ struct RTKSavingsCardView: View {
 
             row("Today", savings.todaySaved, floor: savings.todayFloor, ceiling: savings.todayCeiling)
             row("Last 7 days", savings.weekSaved, floor: savings.weekFloor, ceiling: savings.weekCeiling)
-            row("Month to date", savings.monthSaved, floor: savings.monthFloor, ceiling: savings.monthCeiling)
+            row("Last 30 days", savings.last30Saved, floor: savings.last30Floor, ceiling: savings.last30Ceiling)
 
             Divider()
                 .background(Theme.divider)
@@ -109,7 +109,7 @@ struct RTKSavingsCardView: View {
     RTKSavingsCardView(savings: RTKSavings(
         todaySaved: 42_842,
         weekSaved: 31_819_035,
-        monthSaved: 45_659_821,
+        last30Saved: 45_659_821,
         lifetimeSaved: 79_609_145,
         lifetimeRaw: 115_000_000,
         commandCount: 19_574,

--- a/ClaudeCodeStats/ClaudeCodeStats/Views/SpendCardView.swift
+++ b/ClaudeCodeStats/ClaudeCodeStats/Views/SpendCardView.swift
@@ -18,7 +18,7 @@ struct SpendCardView: View {
 
             row("Today", spend.today)
             row("Last 7 days", spend.week)
-            row("Month to date", spend.month)
+            row("Last 30 days", spend.last30)
 
             if !spend.daily.isEmpty {
                 Divider()
@@ -27,11 +27,11 @@ struct SpendCardView: View {
                 SpendChartView(daily: spend.daily)
             }
 
-            if !spend.monthByModel.isEmpty {
+            if !spend.last30ByModel.isEmpty {
                 Divider()
                     .background(Theme.divider)
 
-                ForEach(spend.monthByModel) { entry in
+                ForEach(spend.last30ByModel) { entry in
                     HStack {
                         Text(entry.model)
                             .font(.system(size: 10))
@@ -78,8 +78,8 @@ struct SpendCardView: View {
     return SpendCardView(spend: SpendData(
         today: 179.60,
         week: 1301.38,
-        month: 3778.49,
-        monthByModel: [
+        last30: 3778.49,
+        last30ByModel: [
             ModelSpend(model: "Fable 5", cost: 1933.21),
             ModelSpend(model: "Opus 4.8", cost: 1698.25),
             ModelSpend(model: "Sonnet 5", cost: 145.61),


### PR DESCRIPTION
## What

Replaces the "Month to date" row with a rolling **"Last 30 days"** on both the API-Equivalent Spend card and the RTK Savings card.

## Why

`Today` and `Last 7 days` are already rolling windows; `Month to date` was the calendar-anchored odd one out, and it reads near-empty early in the month. A rolling 30-day window (today plus the 29 days before it) gives a steadier sense of the monthly rhythm and keeps the card's three windows consistent in style.

## Notes

- The spend window reuses the existing `chartWindowDays` (30), so the **"Last 30 days" total is now exactly the sum of the bars in the chart below it** — previously the headline number and the chart covered different spans. The per-model breakdown follows the same window.
- RTK's SQL window boundary moves from calendar-month-start to `today − 29 days`, mirroring `CostService`.
- **No `cacheVersion` bump**: this is aggregation-only over the already-cached per-day rollups (`retentionDays = 100` covers 30 days with room to spare), and the per-entry cost formula and parsing are unchanged.

## Verification

Built (Xcode Release) and ran the dev build on macOS. Both cards show "Last 30 days"; the spend figure matches the summed chart bars. Rename-only for the field names (`month*` → `last30*`), so no behavioural change beyond the window itself.
