### PR TITLE
Give the menu bar rings the dark appearance step

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,17 +11,33 @@ cd ClaudeCodeStats
 xcodebuild -scheme ClaudeCodeStats -configuration Release build
 ```
 
-The built `.app` is in `~/Library/Developer/Xcode/DerivedData/ClaudeCodeStats-*/Build/Products/Release/`.
+The built `.app` is in `~/Library/Developer/Xcode/DerivedData/ClaudeCodeStats-<hash>/Build/Products/Release/`.
+
+**Resolve that path explicitly — never with a `ClaudeCodeStats-*` glob.** Xcode keeps a
+separate DerivedData directory per project location, and stale ones are not cleaned up. When
+more than one exists the glob expands to all of them, so `cp -R src1 src2 /Applications/`
+copies the fresh build and then **overwrites it with the stale one**, exit 0 and no warning —
+you end up debugging a binary that is weeks old. `ls -dt` does not save you either: it sorts
+by directory mtime, which a previous `cp` will have touched. The last line `xcodebuild` prints
+(`lsregister -f -R -trusted <path>`) names the directory it actually built into.
 
 To install locally:
 
 ```bash
+# Take the path from xcodebuild's own output, or pick by the *binary's* mtime:
+APP=$(ls -dt ~/Library/Developer/Xcode/DerivedData/ClaudeCodeStats-*/Build/Products/Release/ClaudeCodeStats.app/Contents/MacOS/ClaudeCodeStats \
+      | head -1 | sed 's#/Contents/MacOS/ClaudeCodeStats##')
+echo "installing from: $APP"   # sanity-check this before continuing
+
 # Kill running instance, copy to /Applications, relaunch
 pkill -x ClaudeCodeStats; sleep 0.5
 rm -rf /Applications/ClaudeCodeStats.app
-cp -R ~/Library/Developer/Xcode/DerivedData/ClaudeCodeStats-*/Build/Products/Release/ClaudeCodeStats.app /Applications/
+cp -R "$APP" /Applications/ClaudeCodeStats.app
 open /Applications/ClaudeCodeStats.app
 ```
+
+If a change you just made doesn't show up, check this first: a rendered colour or string that
+exists nowhere in the source tree means you are not running the tree.
 
 There are no tests or linters configured, so verifying a change means running the app and looking at it. Three non-obvious traps when doing that from a shell:
 

--- a/ClaudeCodeStats/ClaudeCodeStats/Theme.swift
+++ b/ClaudeCodeStats/ClaudeCodeStats/Theme.swift
@@ -98,4 +98,96 @@ enum Theme {
             ? NSColor(red: 35/255, green: 35/255, blue: 35/255, alpha: 1)
             : NSColor(red: 235/255, green: 235/255, blue: 235/255, alpha: 1)
     }))
+
+    // Severity ramp — cyan, orange, purple. The obvious green/yellow/red loses
+    // most of its meaning twice over: on a light background the green and
+    // yellow sat at 1.7:1 and 1.5:1, well under the 3:1 WCAG floor for non-text
+    // UI, and under deuteranopia all three collapse into shades of olive
+    // (#C2C284 / #DBDB00 / #A8A86B — ΔE 9.5 between the outer two, which is no
+    // difference at all). This ramp keeps every pair at ΔE ≥ 41 under
+    // protanopia, deuteranopia and tritanopia alike, and every step clears 3:1
+    // on all four surfaces. Purple rather than red for the top step is the
+    // price: red can't hold that separation from orange without a lightness
+    // gap that the light-mode contrast floor forbids. See issue #29.
+    //
+    // Measured on each real surface, worst of the three steps:
+    //   light popover #FFFFFF  5.18:1    light menu bar #DCDCDC  3.78:1
+    //   dark popover  #2A2A2A  3.63:1    dark menu bar  #272727  3.78:1
+    //
+    // The light menu bar is the tightest of the four, because it is translucent
+    // over the wallpaper rather than the #F2F2F2 an opaque bar would give. That
+    // is what puts the warning step at orange-700 and not the orange-600 the
+    // popover could otherwise carry: on a #DCDCDC bar orange-600 is 2.60:1.
+    //
+    // The menu bar takes the same pair as the popover, not a fixed mid-tone.
+    // Its rings are rasterised into an NSImage, but the drawing handler runs at
+    // draw time under the menu bar's own appearance, so a dynamic colour
+    // resolves to the right step there — the labels next to the rings already
+    // rely on this, via `NSColor.labelColor`. Pinning them to the light step
+    // instead left the two commonest states at 2.86:1 and 2.85:1 on a real
+    // #252525 menu bar: under the floor, and visibly washed out.
+    static let statusOKColor = NSColor.statusStep(
+        light: NSColor(red: 14/255, green: 116/255, blue: 144/255, alpha: 1),
+        dark: NSColor(red: 103/255, green: 232/255, blue: 249/255, alpha: 1))
+
+    static let statusWarningColor = NSColor.statusStep(
+        light: NSColor(red: 194/255, green: 65/255, blue: 12/255, alpha: 1),
+        dark: NSColor(red: 252/255, green: 211/255, blue: 77/255, alpha: 1))
+
+    static let statusCriticalColor = NSColor.statusStep(
+        light: NSColor(red: 147/255, green: 51/255, blue: 234/255, alpha: 1),
+        dark: NSColor(red: 168/255, green: 85/255, blue: 247/255, alpha: 1))
+
+    static let statusOK = Color(nsColor: Theme.statusOKColor)
+    static let statusWarning = Color(nsColor: Theme.statusWarningColor)
+    static let statusCritical = Color(nsColor: Theme.statusCriticalColor)
+}
+
+private extension NSColor {
+    /// Pairs a light step with a dark one, matching the two-step approach the
+    /// rest of `Theme` uses: a single saturated hue can't sit inside the
+    /// readable lightness band against white and against #2A2A2A at once.
+    static func statusStep(light: NSColor, dark: NSColor) -> NSColor {
+        NSColor(name: nil, dynamicProvider: { appearance in
+            appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua ? dark : light
+        })
+    }
+}
+
+/// How close a limit is to being hit.
+///
+/// The thresholds and their colours live here so the usage bars, the menu bar
+/// rings and the status dot can't drift apart — they were three separate copies
+/// of the same triple before.
+enum StatusLevel {
+    case ok
+    case warning
+    case critical
+
+    init(usagePercent: Double) {
+        switch usagePercent {
+        case ..<50: self = .ok
+        case ..<75: self = .warning
+        default: self = .critical
+        }
+    }
+
+    /// For SwiftUI surfaces, which resolve against the appearance in effect.
+    var color: Color {
+        switch self {
+        case .ok: return Theme.statusOK
+        case .warning: return Theme.statusWarning
+        case .critical: return Theme.statusCritical
+        }
+    }
+
+    /// The same step as `color`, for the menu bar rings — they're drawn with
+    /// Core Graphics, which needs the `NSColor` rather than the SwiftUI one.
+    var menuBarColor: NSColor {
+        switch self {
+        case .ok: return Theme.statusOKColor
+        case .warning: return Theme.statusWarningColor
+        case .critical: return Theme.statusCriticalColor
+        }
+    }
 }


### PR DESCRIPTION
Part of #29, reported by @maxxedev:

> Please make colors easier to distinguish for low-contrast monitors and/or for
> color-blind users. Right now, colors can be different shades of same color like red.

Both halves of that are load-bearing here, and the menu bar was failing the first one.

## Why

The severity ramp's menu bar rings were pinned to the ramp's **light** step in both
appearances. The code comment justified that by saying art rasterised into an `NSImage`
can never see the appearance.

That premise is wrong. The drawing handler runs **at draw time**, under the destination's
appearance, so a dynamic `NSColor` resolves to the correct step inside it. I verified this
with a standalone harness that draws one `NSImage` twice, and the labels drawn beside the
rings already depended on it via `NSColor.labelColor`:

```
drawn under .aqua     : rgb(255, 0, 0)  -> aqua variant
drawn under .darkAqua : rgb(0, 0, 255)  -> darkAqua variant
```

Pinning them cost most of the contrast the ramp exists to provide. Sampled off a real
menu bar, the OK step rendered `#007C95` against a `#272727` bar — **2.97:1**, *under* the
3:1 WCAG floor for non-text UI that the comment claimed it cleared. So the accessibility
change was failing its own goal in the one place the colour is the entire signal.

## What changed

Each step is now a light/dark pair, and the menu bar takes the **same** pair as the popover
instead of a fixed mid-tone. The separate `*MenuBar` constants collapse into one pair per
step, so the two surfaces can no longer drift apart.

| | before | after |
|---|---|---|
| OK ring, dark bar | `#007C95` @ 2.97:1 | `#59E9F8` @ **10.28:1** |

That is ahead of the green/yellow/red it replaced (8.49:1) while keeping the colour-blind
separation that ramp lacked — ΔE 41 at the worst pair, versus ΔE 9.2.

Measuring the light bar turned up a second miss. It is translucent over the wallpaper, so
it samples **`#DCDCDC`**, not the `#F2F2F2` an opaque bar would give — and the warning step
sat at 2.60:1 there. Moved orange-600 → orange-700; now 3.78:1, worst-pair separation
unchanged at ΔE 48.5.

Every step now clears 3:1 on all four surfaces, **measured rather than assumed**:

```
light popover #FFFFFF  5.18:1    light menu bar #DCDCDC  3.78:1
dark popover  #2A2A2A  3.63:1    dark menu bar  #272727  3.78:1
```

## Also: the install command in CLAUDE.md

Xcode keeps one DerivedData directory per project location and never prunes stale ones.
With two present, the documented `ClaudeCodeStats-*` glob expands to both, so
`cp -R src1 src2 /Applications/` installs the fresh build and then **overwrites it with the
older one** — exit 0, no warning. This cost a cycle here: the rings kept rendering a green
that exists nowhere in the source tree. `ls -dt` doesn't save you either; it sorts by
directory mtime, which a previous `cp` will have touched.

Replaced with a resolve-by-binary-mtime snippet (verified against the two-directory case
that broke) plus the tell to check first.

## ⚠️ Scope against #29 — deliberately does **not** close it

Two reasons this references #29 rather than closing it:

1. **The consumers are still uncommitted local work.** `Theme.swift` here defines the ramp,
   but `drawRing`, `ProgressBarView`, `StatusService`, `ContentView` and `SettingsView` are
   not in this PR. On this branch the ramp is unreferenced and the rings still render the old
   inline green/yellow/red — so merging this alone changes nothing a user would see.
2. **The favicon half of #29 is untouched.** The issue also asks for a favicon; nothing here
   addresses that.

Auto-closing on merge would shut a user's issue while their reported symptom is still on
screen, so #29 stays open until the consumers and the favicon land.

## Verification

- `xcodebuild -scheme ClaudeCodeStats -configuration Release build` on the branch tip, in a
  clean worktree with no local files: **BUILD SUCCEEDED**
- Colours sampled from live `screencapture` pixels of the real menu bar in both appearances,
  not eyeballed and not computed from assumed backgrounds
- Contrast and CIE76 ΔE under protanopia / deuteranopia / tritanopia (Machado 2009, severity
  1.0) computed for every pair on every surface
